### PR TITLE
Modify launcher to support "fast-sync"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "casper-node-launcher"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
 
 [[package]]
 name = "atty"
@@ -51,9 +51,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091bcdf2da9950f96aa522681ce805e6857f6ca8df73833d35736ab2dc78e152"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -91,27 +91,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -157,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -209,9 +197,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "log"
@@ -224,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -236,6 +224,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -249,33 +246,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.19.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
+ "memoffset",
 ]
 
 [[package]]
@@ -303,15 +282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +289,9 @@ checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -349,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -461,21 +431,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 dependencies = [
- "semver-parser",
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -500,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -551,9 +511,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -665,12 +625,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "7507ec620f809cdf07cccb5bc57b13069a88031b795efd4079b1c71b66c1613d"
 dependencies = [
  "ansi_term",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
@@ -684,12 +643,6 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "casper-node-launcher"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-launcher"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>", "Joe Sacher <joe@casperlabs.io>"]
 edition = "2018"
 description = "A binary which runs and upgrades the casper-node of the Casper network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = "1.0.38"
 backtrace = "0.3.56"
 clap = "3.0.0-beta.2"
 once_cell = "1.5.2"
-nix = "0.19.1"
-semver = { version = "0.11.0", features = ["serde"] }
+nix = "0.23.0"
+semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0.120", features = ["derive"] }
 signal-hook = "0.3.4"
 toml = "0.5.8"
 tracing = "0.1.22"
-tracing-subscriber = { version = "0.2.15", features = ["json"] }
+tracing-subscriber = { version = "0.3.2", features = ["json", "env-filter"] }
 
 [dev-dependencies]
 once_cell = "1.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-launcher"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>", "Joe Sacher <joe@casperlabs.io>"]
 edition = "2018"
 description = "A binary which runs and upgrades the casper-node of the Casper network"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,26 @@ A binary which runs and upgrades the casper-node of the Casper network.
 
 ## Usage
 
-The casper-node-launcher takes no arguments other than the standard `--help` and `--version`.
+```
+    casper-node-launcher [OPTIONS]
 
-On startup, the launcher either tries to read its previously cached state from disk, or assumes a fresh start.  On a
-fresh start, the launcher searches for the lowest installed version of `casper-node` and starts running it in validator
-mode.
+OPTIONS:
+    -f, --force-version <version>    Forces the launcher to run the specified version of the node,
+                                     for example "1.2.3"
+    -h, --help                       Print help information
+    -V, --version                    Print version information
+```
+
+On startup, launcher checks whether the installed node binaries match the installed configs,
+by comparing the version numbers.  If not, it exits with an error.
+
+The launcher then checks if the `--force-version` parameter was provided.  If yes, it will unconditionally
+run the specified node, given it is installed.  The requested version is then cached in the state,
+so the subsequent runs of the launcher will continue to execute the previously requested version.
+
+If the `--force-version` parameter was not provided the launcher either tries to read its previously cached state
+from disk, or assumes a fresh start.  On a fresh start, the launcher searches for the highest installed
+version of `casper-node` and starts running it in validator mode.
 
 After every run of the `casper-node` binary in validator mode, the launcher does the following based upon the exit code
 returned by `casper-node`:

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -229,8 +229,6 @@ impl Launcher {
 
         // We are guaranteed to have at least one version in the `all_versions` container,
         // because if there are no valid versions installed the `utils::versions_from_path()` will bail.
-        if all_versions.is_empty() {}
-
         if let Some(most_recent_version) = all_versions.into_iter().last() {
             Ok(most_recent_version)
         } else {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -179,7 +179,7 @@ impl Launcher {
         let all_versions = utils::versions_from_path(&Self::binary_root_dir())?;
 
         // We are guaranteed to have at least one version in the `all_versions` container,
-        // because if there are no valid version installed the `utils::versions_from_path()` will bail.
+        // because if there are no valid versions installed the `utils::versions_from_path()` will bail.
         if all_versions.is_empty() {}
 
         if let Some(most_recent_version) = all_versions.into_iter().last() {
@@ -555,8 +555,7 @@ mod tests {
     fn should_run_most_recent_version_when_state_file_absent() {
         let _ = logging::init();
 
-        // Set up the test folders as if casper-node has just been staged at v3.0.0,
-        // but create the state file, so that the launcher launches the v1.0.0.
+        // Set up the test folders as if casper-node has just been staged at v3.0.0.
         install_mock(&*V1, true);
         install_mock(&*V2, true);
         install_mock(&*V3, true);

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -140,9 +140,9 @@ impl Launcher {
                 let mut launcher = Launcher::default();
 
                 let maybe_state = launcher.try_load_state()?;
-                info!(path=%launcher.state_path().display(), "read stored state");
                 match maybe_state {
                     Some(read_state) => {
+                        info!(path=%launcher.state_path().display(), "read stored state");
                         launcher.state = read_state;
                         Ok(launcher)
                     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -229,12 +229,10 @@ impl Launcher {
 
         // We are guaranteed to have at least one version in the `all_versions` container,
         // because if there are no valid versions installed the `utils::versions_from_path()` bails.
-        if let Some(most_recent_version) = all_versions.into_iter().last() {
-            Ok(most_recent_version)
-        } else {
-            // `utils::versions_from_path()` will log a message for us
-            unreachable!();
-        }
+        Ok(all_versions
+            .into_iter()
+            .last()
+            .expect("must have at least one version"))
     }
 
     /// Gets the next installed version of the node binary and config.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -228,7 +228,7 @@ impl Launcher {
         let all_versions = utils::versions_from_path(&Self::binary_root_dir())?;
 
         // We are guaranteed to have at least one version in the `all_versions` container,
-        // because if there are no valid versions installed the `utils::versions_from_path()` will bail.
+        // because if there are no valid versions installed the `utils::versions_from_path()` bails.
         if let Some(most_recent_version) = all_versions.into_iter().last() {
             Ok(most_recent_version)
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -197,7 +197,7 @@ mod tests {
 
         // Try with a non-existent dir.
         let non_existent_dir = Path::new("not_a_dir");
-        let error = next_installed_version(&non_existent_dir, &current_version)
+        let error = next_installed_version(non_existent_dir, &current_version)
             .unwrap_err()
             .to_string();
         assert_eq!(


### PR DESCRIPTION
* When launcher is run without the state file being present, it launches the most recent version of the node
* Added new option to allow manual selection of the node version to run
```
    -f, --force-version <version>    Forces the launcher to run the specified version of the node,
                                     for example "1.2.3"
```

Closes https://github.com/casper-network/casper-node/issues/2379