### PR TITLE
Add support for shutdown script run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Security:   in case of vulnerabilities)
 
 ## [Unreleased]
-
+### Added
+* Launcher now handles node exit code `103` by running a script at `/etc/casper/casper_shutdown_script` and exiting with its exit code if present, otherwise returning 0.
 
 ## [1.0.0] - 2022-01-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "atty",
  "bitflags",
  "indexmap",
+ "lazy_static",
  "os_str_bytes",
  "strsim",
  "termcolor",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ returned by `casper-node`:
   * If 0 (success), searches for the immediate next installed version of `casper-node` and runs it in migrate-data mode
   * If 102 (downgrade), searches for the immediate previous installed version of `casper-node` and runs it in validator
     mode
+  * If 103 (shutdown), runs the script at `/etc/casper/casper_shutdown_script` if present and exits with its exit code,
+    otherwise exits with `0`.
   * Any other value causes the launcher to exit with an error
 
 After every run of the `casper-node` binary in migrate-data mode, the launcher does the following based upon the exit

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ code returned by `casper-node`:
   * If 0 (success), runs the same version of `casper-node` in validator mode
   * If 102 (downgrade), searches for the immediate previous installed version of `casper-node` and runs it in validator
     mode
+  * If 103 (shutdown), runs the script at `/etc/casper/casper_shutdown_script` if present and exits with its exit code,
+    otherwise exits with `0`.
   * Any other value causes the launcher to exit with an error
 
 If the launcher cannot find an appropriate version at any stage of upgrading or downgrading, it exits with an error.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -27,6 +27,7 @@ const STATE_FILE_NAME: &str = "casper-node-launcher-state.toml";
 const SHUTDOWN_SCRIPT_PATH: &str = "/etc/casper/casper_shutdown_script";
 #[cfg(test)]
 const SHUTDOWN_SCRIPT_PATH: &str = "/tmp/test_casper_shutdown_script";
+const SHUTDOWN_TERMINATED_BY_SIGNAL_EXIT_CODE: i32 = 254;
 
 /// The folder under which casper-node binaries are installed.
 #[cfg(not(test))]
@@ -421,7 +422,7 @@ impl Launcher {
             )?;
             status.code().unwrap_or_else(|| {
                 error!("shutdown script was terminated by a signal.");
-                1
+                SHUTDOWN_TERMINATED_BY_SIGNAL_EXIT_CODE
             })
         } else {
             info!(

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -410,18 +410,18 @@ impl Launcher {
     /// with the exit code returned by the script, otherwise returns 0.
     fn run_shutdown_script_and_exit(&mut self) -> Result<()> {
         let exit_code = if Path::new(SHUTDOWN_SCRIPT_PATH).exists() {
-            info!("Running shutdown script at {}.", SHUTDOWN_SCRIPT_PATH);
+            info!("running shutdown script at {}.", SHUTDOWN_SCRIPT_PATH);
             let status = utils::map_and_log_error(
                 Command::new(SHUTDOWN_SCRIPT_PATH).status(),
-                format!("Couldn't execute script at {}", SHUTDOWN_SCRIPT_PATH),
+                format!("couldn't execute script at {}", SHUTDOWN_SCRIPT_PATH),
             )?;
             status.code().unwrap_or_else(|| {
-                error!("Shutdown script was terminated by a signal.");
+                error!("shutdown script was terminated by a signal.");
                 1
             })
         } else {
             info!(
-                "Shutdown script not found at {}, exiting.",
+                "shutdown script not found at {}, exiting.",
                 SHUTDOWN_SCRIPT_PATH
             );
             0
@@ -431,7 +431,7 @@ impl Launcher {
         process::exit(exit_code);
         #[cfg(test)]
         {
-            info!("Terminated process with exit code {}", exit_code);
+            info!("terminated process with exit code {}", exit_code);
             Ok(())
         }
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -514,7 +514,7 @@ mod tests {
             );
         }
 
-        let subdir_name = new_version.to_string().replace(".", "_");
+        let subdir_name = new_version.to_string().replace('.', "_");
 
         // Create the node script contents.
         let old_version = Version::new(new_version.major - 1, new_version.minor, new_version.patch);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,8 @@ pub(crate) enum NodeExitCode {
     Success = 0,
     /// Indicates the node version should be downgraded.
     ShouldDowngrade = 102,
+    /// Indicates the node launcher should attempt to run the shutdown script.
+    ShouldExitLauncher = 103,
 }
 
 /// Iterates the given path, returning the subdir representing the immediate next SemVer version
@@ -124,6 +126,13 @@ pub(crate) fn run_node(mut command: Command) -> Result<NodeExitCode> {
         Some(code) if code == NodeExitCode::ShouldDowngrade as i32 => {
             debug!("finished running {:?} - should downgrade now", command);
             Ok(NodeExitCode::ShouldDowngrade)
+        }
+        Some(code) if code == NodeExitCode::ShouldExitLauncher as i32 => {
+            debug!(
+                "finished running {:?} - trying to run shutdown script now",
+                command
+            );
+            Ok(NodeExitCode::ShouldExitLauncher)
         }
         _ => {
             warn!(%exit_status, "failed running {:?}", command);

--- a/test_resources/shutdown.in
+++ b/test_resources/shutdown.in
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This script is used to test that the launcher correctly interprets an exit code of 103 as an instruction to exit
+# and run the shutdown script.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION=""
+MESSAGE="Node v${VERSION} shutting down"
+LOG_FILENAME="log.txt"
+
+# In tests, this script will be installed at e.g. <test dir>/bin/1_0_0.  We want to write the log to <test dir>.
+LOG_FILE="$(readlink -f $(dirname ${0})/../..)/${LOG_FILENAME}"
+
+log() {
+    printf "%s\n" "${1}" >> "${LOG_FILE}"
+}
+
+sleep 1
+log "${MESSAGE}"
+exit 103

--- a/test_resources/shutdown.sh
+++ b/test_resources/shutdown.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-# This script is used in the basic `should_run_command_exiting_with_downgrade_code` unit test.
-
-exit 103

--- a/test_resources/shutdown.sh
+++ b/test_resources/shutdown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# This script is used in the basic `should_run_command_exiting_with_downgrade_code` unit test.
+
+exit 103


### PR DESCRIPTION
Fixes https://github.com/casper-network/casper-node/issues/3040

This PR adds support for the `ShouldExitLauncher` exit code. After receiving this exit code, the launcher will run a script at `/etc/casper/casper_shutdown_script` and then exit with its exit code if the script exists, otherwise it will just exit with exit code `0`.

This PR also adds a test for the shutdown script run triggered by the new exit code introduced earlier. Unfortunately, it's very hard to do a negative test here because of the way the code is structured right now and because of `process:exit()`, which would take down the whole test process if ran.