### PR TITLE
CI: Switch to GHA

### DIFF
--- a/.github/workflows/ci-casper-node-launcher.yml
+++ b/.github/workflows/ci-casper-node-launcher.yml
@@ -1,0 +1,56 @@
+---
+name: ci-casper-node-launcher
+
+on:
+  push:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+    paths-ignore:
+      - '**.md'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Update Stable Toolchain
+        run: rustup update stable
+
+      - name: fmt
+        run: cargo fmt -- --check
+
+      - name: clippy
+        run: cargo clippy -- --deny warnings
+
+      - name: audit
+        run: cargo audit --deny warnings  --ignore RUSTSEC-2021-0119 --ignore RUSTSEC-2020-0159
+
+      - name: test
+        run: cargo test
+
+      - name: deb
+        run: cargo deb
+
+      - name: rpm
+        run: |
+          cargo build --release
+          cargo generate-rpm

--- a/.github/workflows/ci-casper-node-launcher.yml
+++ b/.github/workflows/ci-casper-node-launcher.yml
@@ -25,14 +25,14 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
 
-      - name: Update Stable Toolchain
+      - name: update stable toolchain
         run: rustup update stable
 
       - name: fmt
@@ -42,10 +42,15 @@ jobs:
         run: cargo clippy -- --deny warnings
 
       - name: audit
-        run: cargo audit --deny warnings  --ignore RUSTSEC-2021-0119 --ignore RUSTSEC-2020-0159
+        run: cargo audit --deny warnings
 
       - name: test
         run: cargo test
+
+      - name: install cargo packaging tools
+        run: |
+          cargo install cargo-deb
+          cargo install cargo-generate-rpm
 
       - name: deb
         run: cargo deb

--- a/.github/workflows/publish-casper-node-launcher-deb.yml
+++ b/.github/workflows/publish-casper-node-launcher-deb.yml
@@ -1,0 +1,69 @@
+---
+name: publish-casper-node-launcher-deb
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish_deb:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            code_name: bionic
+          - os: ubuntu-20.04
+            code_name: focal
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Install deps
+        run: |
+          echo "deb http://repo.aptly.info/ squeeze main" | sudo tee -a /etc/apt/sources.list.d/aptly.list
+          wget -qO - https://www.aptly.info/pubkey.txt | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y awscli aptly=1.2.0
+          aptly config show
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@c8bb57c57e8df1be8c73ff3d59deab1dbc00e0d1 #v5.1.0
+        with:
+          gpg_private_key: ${{ secrets.APTLY_GPG_KEY }}
+          passphrase: ${{ secrets.APTLY_GPG_PASS }}
+
+      - name: Install cargo deb
+        run: cargo install cargo-deb
+
+      - name: Cargo build
+        run: cargo build --release
+
+      - name: Cargo deb
+        run: cargo deb --no-build --variant ${{ matrix.code_name }}
+
+      - name: Upload binaries to repo
+        env:
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
+          PLUGIN_REPO_NAME: ${{ secrets.APTLY_REPO }}
+          PLUGIN_REGION: ${{ secrets.APTLY_REGION }}
+          PLUGIN_GPG_KEY: ${{ secrets.APTLY_GPG_KEY }}
+          PLUGIN_GPG_PASS: ${{ secrets.APTLY_GPG_PASS }}
+          PLUGIN_ACL: 'public-read'
+          PLUGIN_PREFIX: 'releases'
+          PLUGIN_DEB_PATH: './target/debian'
+          PLUGIN_OS_CODENAME: ${{ matrix.code_name }}
+        run: ./ci/publish_deb_to_repo.sh
+
+      - name: Invalidate cloudfront
+        uses: chetan/invalidate-cloudfront-action@c384d5f09592318a77b1e5c0c8d4772317e48b25 #v2.4
+        env:
+          DISTRIBUTION: ${{ secrets.APTLY_DIST_ID }}
+          PATHS: "/*"
+          AWS_REGION: ${{ secrets.APTLY_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}

--- a/.github/workflows/publish-casper-node-launcher-deb.yml
+++ b/.github/workflows/publish-casper-node-launcher-deb.yml
@@ -15,12 +15,16 @@ jobs:
             code_name: bionic
           - os: ubuntu-20.04
             code_name: focal
+          - os: ubuntu-22.04
+            code_name: jammy
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+        with:
+          key: ${{ matrix.code_name }}
 
       - name: Install deps
         run: |
@@ -67,3 +71,11 @@ jobs:
           AWS_REGION: ${{ secrets.APTLY_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575 #v2.3.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/debian/casper-node-launcher*
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/.github/workflows/publish-casper-node-launcher-rpm.yml
+++ b/.github/workflows/publish-casper-node-launcher-rpm.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-rpm:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm awscli createrepo
+          sudo apt-get install -y rpm awscli createrepo-c
 
       - name: Install cargo-generate-rpm
         run: cargo install cargo-generate-rpm
@@ -47,6 +47,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.RPM_REPO_AK }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RPM_REPO_SK }}
+          AWS_DEFAULT_REGION: ${{ secrets.RPM_REPO_REGION }}
         run: ./ci/publish_rpm_to_repo.sh source_dir="./target/generate-rpm" target_bucket=${{secrets.RPM_BUCKET}}
 
       - name: Invalidate cloudfront

--- a/.github/workflows/publish-casper-node-launcher-rpm.yml
+++ b/.github/workflows/publish-casper-node-launcher-rpm.yml
@@ -1,0 +1,67 @@
+---
+name: publish-casper-node-launcher-rpm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish-rpm:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm awscli createrepo
+
+      - name: Install cargo-generate-rpm
+        run: cargo install cargo-generate-rpm
+
+      - name: Build release target
+        run: cargo build --release
+
+      - name: Strip debug symbols
+        run: strip -s target/release/casper-node-launcher
+
+      - name: Generate rpm
+        run: cargo generate-rpm
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@c8bb57c57e8df1be8c73ff3d59deab1dbc00e0d1 #v5.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PK }}
+          passphrase: ${{ secrets.GPG_PP }}
+
+      - name: Sign rpm
+        run: |
+          cp ci/rpmmacros ~/.rpmmacros
+          rpmsign --addsign ./target/generate-rpm/casper-node-launcher*.rpm
+
+      - name: Upload to s3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RPM_REPO_AK }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RPM_REPO_SK }}
+        run: ./ci/publish_rpm_to_repo.sh source_dir="./target/generate-rpm" target_bucket=${{secrets.RPM_BUCKET}}
+
+      - name: Invalidate cloudfront
+        uses: chetan/invalidate-cloudfront-action@c384d5f09592318a77b1e5c0c8d4772317e48b25 #v2.4
+        env:
+          DISTRIBUTION: ${{ secrets.DISTRIBUTION_ID }}
+          PATHS: "/*"
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: ${{ secrets.RPM_REPO_AK }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RPM_REPO_SK }}
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575 #v2.3.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/generate-rpm/casper-node-launcher*
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "atty"
@@ -51,9 +51,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -103,40 +103,49 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.7.0"
+name = "clap_lex"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -149,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -168,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "lazy_static"
@@ -180,15 +189,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -204,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -219,12 +228,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -242,48 +250,45 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -296,18 +301,18 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "regex-syntax",
 ]
@@ -323,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -344,33 +349,33 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -379,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -399,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -418,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "strsim"
@@ -430,13 +435,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -479,18 +484,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -500,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -511,19 +516,19 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.25"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfce9f3241b150f36e8e54bb561a742d5daa1a47b5dd9a5ce369fd4a4db2210"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -542,13 +547,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -562,10 +567,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,26 +54,24 @@ For information on using package, see https://github.com/CasperLabs/casper-node-
 unit-scripts = "./resources/maintainer_scripts/casper_node_launcher"
 restart-after-upgrade = false
 
-[package.metadata.rpm]
-package = "casper-node-launcher"
+[package.metadata.deb.variants.bionic]
+revision = "0+bionic"
 
-[package.metadata.rpm.cargo]
-buildflags = ["--release"]
+[package.metadata.deb.variants.focal]
+revision = "0+focal"
 
-[package.metadata.rpm.systemd-units]
-unit-scripts = "./resources/maintainer_scripts/casper_node_launcher"
-restart-after-upgrade = false
-
-[package.metadata.rpm.targets]
-casper-node-launcher = { path = "/usr/bin/casper-node-launcher" }
-"../../resources/BIN_README.md" = {path = "/var/lib/casper/bin/README.md"}
-"../../resources/PLATFORM_RPM" = {path = "/etc/casper/PLATFORM"}
-"../../resources/maintainer_scripts/logrotate.d/casper-node" = {path = "/etc/logrotate.d/casper-node"}
-"../../resources/maintainer_scripts/pull_casper_node_version.sh" = {path = "/etc/casper/pull_casper_node_version.sh"}
-"../../resources/maintainer_scripts/network_configs/casper.conf" = {path = "/etc/casper/network_configs/casper.conf"}
-"../../resources/maintainer_scripts/network_configs/casper-test.conf" = {path = "/etc/casper/network_configs/casper-test.conf"}
-"../../resources/maintainer_scripts/config_from_example.sh" = {path = "/etc/casper/config_from_example.sh"}
-"../../resources/maintainer_scripts/node_util.py" = {path = "/etc/casper/node_util.py"}
-"../../resources/ETC_README.md" = {path = "/etc/casper/README.md"}
-"../../resources/VALIDATOR_KEYS_README.md" = {path = "/etc/casper/validator_keys/README.md"}
-"../../resources/maintainer_scripts/casper_node_launcher/casper-node-launcher.service" = {path = "/etc/systemd/system/casper-node-launcher.service"}
+[package.metadata.generate-rpm]
+license = "Apache 2.0"
+assets = [
+    { source = "target/release/casper-node-launcher", dest = "/usr/bin/casper-node-launcher", mode = "0755" },
+    { source = "resources/BIN_README.md", dest = "/var/lib/casper/bin/README.md", doc = true, mode = "0644" },
+    { source = "resources/PLATFORM_RPM", dest = "/etc/casper/PLATFORM", doc = true, mode = "0644" },
+    { source = "resources/maintainer_scripts/logrotate.d/casper-node", dest = "/etc/logrotate.d/casper-node", mode = "0644" },
+    { source = "resources/maintainer_scripts/pull_casper_node_version.sh", dest = "/etc/casper/pull_casper_node_version.sh", mode = "0755" },
+    { source = "resources/maintainer_scripts/network_configs/*", dest = "/etc/casper/network_configs/", mode = "0644" },
+    { source = "resources/maintainer_scripts/config_from_example.sh", dest = "/etc/casper/config_from_example.sh", mode = "0755" },
+    { source = "resources/maintainer_scripts/node_util.py", dest = "/etc/casper/node_util.py", mode = "0755" },
+    { source = "resources/ETC_README.md", dest = "/etc/casper/README.md", doc = true, mode = "0644" },
+    { source = "resources/VALIDATOR_KEYS_README.md", dest = "/etc/casper/validator_keys/README.md", doc = true, mode = "0644" },
+    { source = "resources/maintainer_scripts/casper_node_launcher/casper-node-launcher.service", dest = "/lib/systemd/system/casper-node-launcher.service", mode = "0644" }
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,16 @@ unit-scripts = "./resources/maintainer_scripts/casper_node_launcher"
 restart-after-upgrade = false
 
 [package.metadata.deb.variants.bionic]
+name = "casper-node-launcher"
 revision = "0+bionic"
 
 [package.metadata.deb.variants.focal]
+name = "casper-node-launcher"
 revision = "0+focal"
+
+[package.metadata.deb.variants.jammy]
+name = "casper-node-launcher"
+revision = "0+jammy"
 
 [package.metadata.generate-rpm]
 license = "Apache 2.0"

--- a/ci/publish_deb_to_repo.sh
+++ b/ci/publish_deb_to_repo.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+# DEFAULTS
+PLUGIN_OS_CODENAME="${PLUGIN_OS_CODENAME:-bionic}"
+
+# Verify all variables are present
+if [[ -z $PLUGIN_GPG_KEY || -z $PLUGIN_GPG_PASS || -z $PLUGIN_REGION \
+        || -z $PLUGIN_REPO_NAME || -z $PLUGIN_ACL || -z $PLUGIN_PREFIX \
+        || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID \
+        || -z $PLUGIN_DEB_PATH || -z $PLUGIN_OS_CODENAME ]]; then
+    echo "ERROR: Environment Variable Missing!"
+    exit 1
+fi
+
+# Verify if its the first time publishing. Will need to know later.
+# Probably an easier way to do this check :)
+EXISTS=$(aws s3 ls s3://"$PLUGIN_REPO_NAME"/releases/dists/ --region "$PLUGIN_REGION" | grep "$PLUGIN_OS_CODENAME") || EXISTS_RET="false"
+
+# Sanity Check for later
+if [ "$EXISTS_RET" = "false" ]; then
+    echo "First time uploading repo!"
+else
+    echo "Repo Exists! Defaulting to publish update..."
+fi
+
+### APTLY SECTION
+
+# Move old config file to use in jq query
+mv ~/.aptly.conf ~/.aptly.conf.orig
+
+# Inject ENV Variables and save as .aptly.conf
+jq --arg region "$PLUGIN_REGION" --arg bucket "$PLUGIN_REPO_NAME" --arg acl "$PLUGIN_ACL" --arg prefix "$PLUGIN_PREFIX"   '.S3PublishEndpoints[$bucket] = {"region":$region, "bucket":$bucket, "acl": $acl, "prefix": $prefix}' ~/.aptly.conf.orig > ~/.aptly.conf
+
+# If aptly repo DOESNT exist locally already
+if [ ! "$(aptly repo list | grep $PLUGIN_OS_CODENAME)" ]; then
+    aptly repo create -distribution="$PLUGIN_OS_CODENAME" -component=main "release-$PLUGIN_OS_CODENAME"
+fi
+
+# If aptly mirror DOESNT exist locally already
+if [ ! "$(aptly mirror list | grep $PLUGIN_OS_CODENAME)" ] && [ ! "$EXISTS_RET" = "false" ] ; then
+    aptly mirror create -ignore-signatures "local-repo-$PLUGIN_OS_CODENAME" https://"${PLUGIN_REPO_NAME}"/"${PLUGIN_PREFIX}"/ "${PLUGIN_OS_CODENAME}" main
+fi
+
+# When it's not the first time uploading.
+if [ ! "$EXISTS_RET" = "false" ]; then
+    aptly mirror update -ignore-signatures "local-repo-$PLUGIN_OS_CODENAME"
+    # Found an article that said using 'Name' will select all packages for us
+    aptly repo import "local-repo-$PLUGIN_OS_CODENAME" "release-$PLUGIN_OS_CODENAME" Name
+fi
+
+# Add .debs to the local repo
+aptly repo add -force-replace "release-$PLUGIN_OS_CODENAME" "$PLUGIN_DEB_PATH"/*.deb
+
+# Publish to S3
+if [ ! "$(aptly publish list | grep $PLUGIN_REPO_NAME | grep $PLUGIN_OS_CODENAME)" ]; then
+    # If the repo is new
+    aptly publish repo -batch -force-overwrite -passphrase="$PLUGIN_GPG_PASS" "release-$PLUGIN_OS_CODENAME" s3:"${PLUGIN_REPO_NAME}":
+else
+    # If the repo exists
+    aptly publish update -batch -force-overwrite -passphrase="$PLUGIN_GPG_PASS" "$PLUGIN_OS_CODENAME" s3:"${PLUGIN_REPO_NAME}":
+fi

--- a/ci/publish_rpm_to_repo.sh
+++ b/ci/publish_rpm_to_repo.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Publishes built RPMs to an s3-backed RPM repo.
+# Author - TV
+
+set -e
+
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") source_dir="arg" target_bucket="arg" 
+
+Uploads rpms from <source_dir> to <target_bucket>.
+
+Required options:
+
+source_dir     Directory containing RPM(s) to upload
+target_bucket  S3 bucket name
+
+EOF
+  exit
+}
+
+function main() {
+    local LOCAL_TEMP_DIR
+
+    LOCAL_TEMP_DIR="/tmp/$TARGET_BUCKET"
+    # Create temp directory to use
+    mkdir -p "$LOCAL_TEMP_DIR"
+
+    # Ensure necessary packages are installed
+    dependencies
+    # Sync repo locally
+    sync_from_bucket_to_local "$LOCAL_TEMP_DIR"
+    # Update local repo
+    update_repo "$LOCAL_TEMP_DIR"
+    # Sync it back
+    sync_local_to_bucket "$LOCAL_TEMP_DIR"
+    # Cleanup
+    rm -rf "$LOCAL_TEMP_DIR"
+}
+
+function dependencies() {
+    local DEPS
+
+    DEPS=("aws" "createrepo_c")
+
+    for dep in "${DEPS[@]}"; do
+        if [ ! $(which ${dep}) ]; then
+            echo "please install $dep"
+            exit 1
+        fi
+    done
+}
+
+function sync_from_bucket_to_local() {
+    local TEMP_DIR=${1}
+
+    aws s3 sync "s3://$TARGET_BUCKET" "$TEMP_DIR"
+} 
+    
+function update_repo() { 
+    local TEMP_DIR=${1}
+
+    mkdir -pv "$TEMP_DIR/x86_64/"
+    cp -rv ${SOURCE_DIR}/*.rpm "$TEMP_DIR/x86_64/"
+
+    # Use update flag if not first time
+    if [ -e "$TEMP_DIR/x86_64/repodata/repomd.xml" ]; then
+        createrepo_c -v --update --deltas "$TEMP_DIR/x86_64/"
+    else
+        createrepo_c -v --deltas "$TEMP_DIR/x86_64/"
+    fi
+}
+
+function sync_local_to_bucket() {
+    local TEMP_DIR=${1}
+
+    aws s3 sync "$TEMP_DIR" "s3://$TARGET_BUCKET"
+}
+
+# Entry
+unset SOURCE_DIR
+unset TARGET_BUCKET
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        source_dir) SOURCE_DIR=${VALUE} ;;
+        target_bucket) TARGET_BUCKET=${VALUE} ;;
+        *help) usage ;;
+        -h) usage ;;
+        *) usage ;;
+    esac
+done
+
+if [ -z "$SOURCE_DIR" ] || [ -z "$TARGET_BUCKET" ]; then
+    usage
+fi
+
+main

--- a/ci/rpmmacros
+++ b/ci/rpmmacros
@@ -1,0 +1,3 @@
+%_gpg_name casperlabs <info@casperlabs.io>
+%_gpg_path /home/runner/.gnupg
+%__gpg /usr/bin/gpg2

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -209,10 +209,10 @@ impl Launcher {
                     format!("failed to read {}", state_path.display()),
                 )?;
 
-                return Ok(Some(utils::map_and_log_error(
+                Ok(Some(utils::map_and_log_error(
                     toml::from_str(&contents),
                     format!("failed to parse {}", state_path.display()),
-                )?));
+                )?))
             })
             .unwrap_or_else(|| {
                 debug!(path=%state_path.display(), "stored state doesn't exist");


### PR DESCRIPTION
- Switches over from `drone` to `gha`
- Swaps `cargo-rpm` to `generate-rpm`
    - see: https://github.com/iqlusioninc/cargo-rpm#-unmaintained-
- Builds deb on 18.04, 20.04, 22.04
    - 18.04 will soon be removed in a separate effort
- Fix for failing lint
- Adjust workflow to match casper-node branching strategy 