### PR TITLE
Update casper-test.conf

### DIFF
--- a/resources/maintainer_scripts/network_configs/casper-test.conf
+++ b/resources/maintainer_scripts/network_configs/casper-test.conf
@@ -1,3 +1,2 @@
-SOURCE_URL=casper-genesis.make.services
+SOURCE_URL=genesis.casper.network
 NETWORK_NAME=casper-test
-BIN_MODE=mainnet


### PR DESCRIPTION
Updated location casper-test.conf points to common genesis.casper.network for default installed conf files.